### PR TITLE
Load push certificate as input stream vs file

### DIFF
--- a/src/main/java/bisq/relay/RelayService.java
+++ b/src/main/java/bisq/relay/RelayService.java
@@ -17,15 +17,10 @@
 
 package bisq.relay;
 
-import java.net.URL;
-
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
 import java.util.concurrent.ExecutionException;
-
-import lombok.extern.slf4j.Slf4j;
 
 
 
@@ -41,6 +36,7 @@ import com.turo.pushy.apns.PushNotificationResponse;
 import com.turo.pushy.apns.util.ApnsPayloadBuilder;
 import com.turo.pushy.apns.util.SimpleApnsPushNotification;
 import com.turo.pushy.apns.util.concurrent.PushNotificationFuture;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class RelayService {
@@ -86,19 +82,17 @@ public class RelayService {
             FirebaseApp.initializeApp(options);
         }
 
-        URL iosCert = classLoader.getResource(IOS_CERTIFICATE_FILE);
+        InputStream iosCert = classLoader.getResourceAsStream(IOS_CERTIFICATE_FILE);
         if (iosCert == null) {
             throw new IOException(IOS_CERTIFICATE_FILE + " does not exist");
         } else {
-            File p12File = new File(iosCert.getFile());
-            log.info("Using iOS certification file {}.", p12File.getAbsolutePath());
             productionApnsClient = new ApnsClientBuilder()
                 .setApnsServer(ApnsClientBuilder.PRODUCTION_APNS_HOST)
-                .setClientCredentials(p12File, "")
+                .setClientCredentials(iosCert, "")
                 .build();
             devApnsClient = new ApnsClientBuilder()
                 .setApnsServer(ApnsClientBuilder.DEVELOPMENT_APNS_HOST)
-                .setClientCredentials(p12File, "")
+                .setClientCredentials(iosCert, "")
                 .build();
         }
     }


### PR DESCRIPTION
Previously the code was attempting to load the push certificate as a
File. This worked within the IDE because the IDE ClassLoader loads
resources directly from the filesystem, but failed when running as a
fat executable jar because the file is nested within the jar file, and
therefore not directly addressable as a normal File. To work
around this, the Apple push certificate is now loaded as an InputStream
just as is done with the Android certificate in the code above it.

Note, however, that initialization of this InputStream still fails as
follows:

    Jul-24 15:54:27.266 [main] ERROR b.r.RelayService: java.io.IOException: Short read of DER length
        java.io.IOException: Short read of DER length
        at sun.security.util.DerInputStream.getLength(DerInputStream.java:582)
        at sun.security.util.DerValue.init(DerValue.java:365)
        at sun.security.util.DerValue.<init>(DerValue.java:320)
        at sun.security.pkcs12.PKCS12KeyStore.engineLoad(PKCS12KeyStore.java:1914)
        at java.security.KeyStore.load(KeyStore.java:1445)
        at com.turo.pushy.apns.P12Util.getFirstPrivateKeyEntryFromP12InputStream(P12Util.java:62)
        at com.turo.pushy.apns.ApnsClientBuilder.setClientCredentials(ApnsClientBuilder.java:222)
        at bisq.relay.RelayService.setup(RelayService.java:95)
        at bisq.relay.RelayService.<init>(RelayService.java:54)
        at bisq.relay.RelayMain.main(RelayMain.java:69)

This occurs both in the IDE as well as at the command line. Perhaps the
file itself is actually corrupt.